### PR TITLE
Make request completion closure escaping

### DIFF
--- a/CoreNetKit/Core/BaseServerRequest.swift
+++ b/CoreNetKit/Core/BaseServerRequest.swift
@@ -48,7 +48,7 @@ open class BaseServerRequest<ResultValueType> {
     }
 
     /// Обработка ответа сервера. При необходимости можно перегрузить метод.
-    open func handle(serverResponse: CoreServerResponse, completion: RequestCompletion) {
+    open func handle(serverResponse: CoreServerResponse, completion: @escaping RequestCompletion) {
         preconditionFailure("This method must be overriden by the subclass")
     }
 }


### PR DESCRIPTION
It can be helpful if we need to make some actions with `DispatchQueue` in handle method of BaseServerRequest. For example for mapping purposes.